### PR TITLE
Do not use blobstore.fi-ts.io for ansible-roles anymore

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -1,6 +1,6 @@
 ansible-roles:
   metal-extensions-roles:
-    repository: https://blobstore.fi-ts.io/cloud-native/ansible-roles/metal-extensions-roles-v0.1.9.tar.gz
+    repository: https://git.f-i-ts.de/cloud-native/metal/metal-extensions-roles
     version: v0.1.9
 binaries:
   metal-stack:


### PR DESCRIPTION
- Deployment roles should not be public
- blobstore.fi-ts.io will need to be removed in the future
- Simplify release uploads because ansible-galaxy can use the role directly (requires `CI_JOB_TOKEN` in Gitlab CI)