### PR TITLE
Back with Gardener 1.11.3.

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -49,25 +49,25 @@ docker-images:
     gardener:
       api-server:
         name: eu.gcr.io/gardener-project/gardener/apiserver
-        tag: v1.10.2
+        tag: v1.11.3
       controller-manager:
         name: eu.gcr.io/gardener-project/gardener/controller-manager
-        tag: v1.10.2
+        tag: v1.11.3
       extension-provider-gcp:
         name: eu.gcr.io/gardener-project/gardener/extensions/provider-gcp
-        tag: v1.11.1
+        tag: v1.12.1
       external-dns:
         name: eu.gcr.io/gardener-project/dns-controller-manager
         tag: v0.7.21
       gardenlet:
         name: eu.gcr.io/gardener-project/gardener/gardenlet
-        tag: v1.10.2
+        tag: v1.11.3
       networking-calico:
         name: registry.fi-ts.io/gardener/gardener-extension-networking-calico
         tag: bdfefa8
       scheduler:
         name: eu.gcr.io/gardener-project/gardener/scheduler
-        tag: v1.10.2
+        tag: v1.11.3
       virtual-apiserver:
         name: k8s.gcr.io/hyperkube
         tag: v1.16.14
@@ -85,7 +85,7 @@ repositories:
         ref: v0.11.1
         url: https://github.com/gardener/etcd-backup-restore.git
       gardener:
-        ref: v1.10.2
+        ref: v1.11.3
         url: https://github.com/gardener/gardener.git
 vectors:
   metal-stack:


### PR DESCRIPTION
In order for the deployment to succeed, it is required to use a helm chart fix and to disable admission controllers. The fix is contained here: https://github.com/metal-stack-attic/gardener/tree/admission-controller-chart-fix