### PR TITLE
Upgrade timescaledb

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -68,7 +68,7 @@ docker-images:
     control-plane:
       accounting-db:
         name: timescale/timescaledb
-        tag: 2.25.1-pg15
+        tag: 2.28.3-pg15
     vmware:
       velero:
         name: velero/velero


### PR DESCRIPTION
v2.28.3 is the last timescaledb version with postgres v15.x support. After this was deployed we can upgrade postgres in the next step and after that move to v2.29.x